### PR TITLE
Fix tax calculation bug

### DIFF
--- a/src/PriceCalculator.php
+++ b/src/PriceCalculator.php
@@ -6,9 +6,7 @@ use MarcelStrahl\PriceCalculator\Helpers\Types\DiscountInterface;
 use MarcelStrahl\PriceCalculator\Helpers\Types\VatInterface;
 
 /**
- * Class PriceCalculator
  * @author Marcel Strahl <info@marcel-strahl.de>
- * @package Src
  */
 class PriceCalculator implements PriceCalculatorInterface
 {
@@ -18,7 +16,7 @@ class PriceCalculator implements PriceCalculatorInterface
     private $vat;
 
     /**
-     * @param $vat
+     * @param VatInterface $vat
      */
     public function __construct(VatInterface $vat)
     {
@@ -70,7 +68,8 @@ class PriceCalculator implements PriceCalculatorInterface
      */
     public function calculatePriceWithSalesTax(float $netPrice): float
     {
-        return (float)round((float)bcmul($netPrice, $this->vat->getVatToCalculate(), 2));
+        $vat = (float)round((float)bcmul($netPrice, bcdiv($this->vat->getVat(), 100, 2), 4), 2);
+        return (float)bcadd($netPrice, $vat, 2);
     }
 
     /**

--- a/tests/PriceCalculatorTest.php
+++ b/tests/PriceCalculatorTest.php
@@ -10,9 +10,7 @@ use PHPUnit\Framework\TestCase;
 use MarcelStrahl\PriceCalculator\PriceCalculator;
 
 /**
- * Class PriceCalculatorTest
  * @author Marcel Strahl <info@marcel-strahl.de>
- * @package Tests
  */
 class PriceCalculatorTest extends TestCase
 {
@@ -184,16 +182,19 @@ class PriceCalculatorTest extends TestCase
     {
         return [
             [
-                252, 300
+                31.51, 37.50
             ],
             [
-                340, 405
+                252, 299.88
+            ],
+            [
+                340, 404.60
             ],
             [
                 200, 238
             ],
             [
-                13, 15
+                13, 15.47
             ],
             [
                 64000, 76160


### PR DESCRIPTION
The sales tax calculation had a miscalculation of 1 cent. This was corrected with this commit.