### PR TITLE
Add CI support for PHP 8.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
           run: "composer test"
 
         - name: "Run PHP CS Check"
-          run: "PHP_CS_FIXER_IGNORE_ENV=1 composer cs-check"
+          run: "composer cs-check"
 
         - name: "Run Psalm"
           run: "composer psalm"
@@ -107,7 +107,7 @@ jobs:
           run: "composer test"
 
         - name: "Run PHP CS Check"
-          run: "PHP_CS_FIXER_IGNORE_ENV=1 composer cs-check"
+          run: "composer cs-check"
 
         - name: "Run Psalm"
           run: "composer psalm"
@@ -151,6 +151,4 @@ jobs:
           run: "composer psalm"
 
         - name: "Run infection"
-          env:
-            INFECTION_BADGE_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
           run: "composer infection-ci"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,3 +116,41 @@ jobs:
           env:
             INFECTION_BADGE_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
           run: "composer infection-ci"
+
+    php84:
+      name: PHP 8.4
+      runs-on: ubuntu-latest
+      steps:
+        - name: "Checkout"
+          uses: "actions/checkout@v4"
+          with:
+            fetch-depth: 2
+
+        - name: "Install PHP 8.4"
+          uses: "shivammathur/setup-php@v2"
+          with:
+            php-version: "8.4"
+
+        - name: "Cache composer packages"
+          uses: "actions/cache@v4"
+          with:
+            path: "~/.composer/cache"
+            key: "php-composer-locked-${{ hashFiles('composer.lock') }}"
+            restore-keys: "php-composer-locked-"
+
+        - name: "Install dependencies with composer"
+          run: "composer install --no-interaction"
+
+        - name: "Run PHPUnit Tests"
+          run: "composer test"
+
+        - name: "Run PHP CS Check"
+          run: "PHP_CS_FIXER_IGNORE_ENV=1 composer cs-check"
+
+        - name: "Run Psalm"
+          run: "composer psalm"
+
+        - name: "Run infection"
+          env:
+            INFECTION_BADGE_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
+          run: "composer infection-ci"

--- a/composer.json
+++ b/composer.json
@@ -16,13 +16,13 @@
     "ext-bcmath": "*"
   },
   "require-dev": {
-    "friendsofphp/php-cs-fixer": "^3.51",
-    "infection/infection": "^0.27.10",
+    "friendsofphp/php-cs-fixer": "^3.68",
+    "infection/infection": "^0.29.10",
     "phpstan/extension-installer": "*",
-    "phpunit/phpunit": "^10.5 | ^11.0",
-    "psalm/plugin-phpunit": "^0.18",
-    "squizlabs/php_codesniffer": "^3.9",
-    "vimeo/psalm": "^5.4"
+    "phpunit/phpunit": "^10.5 | ^11.5",
+    "psalm/plugin-phpunit": "^0.19",
+    "squizlabs/php_codesniffer": "^3.11",
+    "vimeo/psalm": "^5.0|^6.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3.68",
-    "infection/infection": "^0.29.10",
+    "infection/infection": "0.27.10|^0.29.10",
     "phpstan/extension-installer": "*",
     "phpunit/phpunit": "^10.5 | ^11.5",
     "psalm/plugin-phpunit": "^0.19",


### PR DESCRIPTION
This commit introduces a new job in the CI workflow to test the codebase with PHP 8.4. It includes steps for PHP installation, dependency management, and running tests for comprehensive compatibility validation. This ensures our code remains robust across the latest PHP versions.